### PR TITLE
don't coerce input to double with custom metric

### DIFF
--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -1217,19 +1217,21 @@ def pdist(X, metric='euclidean', p=2, w=None, V=None, VI=None):
         if metric == minkowski:
             def dfun(u, v):
                 return minkowski(u, v, p)
+            X = _convert_to_double(X)
         elif metric == wminkowski:
             def dfun(u, v):
                 return wminkowski(u, v, p, w)
+            X = _convert_to_double(X)
         elif metric == seuclidean:
             def dfun(u, v):
                 return seuclidean(u, v, V)
+            X = _convert_to_double(X)
         elif metric == mahalanobis:
             def dfun(u, v):
                 return mahalanobis(u, v, V)
+            X = _convert_to_double(X)
         else:
             dfun = metric
-
-        X = _convert_to_double(X)
 
         k = 0
         for i in xrange(0, m - 1):
@@ -1994,8 +1996,8 @@ def cdist(XA, XB, metric='euclidean', p=2, V=None, VI=None, w=None):
     XB = np.asarray(XB, order='c')
 
     # The C code doesn't do striding.
-    XA = _copy_array_if_base_present(_convert_to_double(XA))
-    XB = _copy_array_if_base_present(_convert_to_double(XB))
+    XA = _copy_array_if_base_present(XA)
+    XB = _copy_array_if_base_present(XB)
 
     s = XA.shape
     sB = XB.shape

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -380,6 +380,19 @@ class TestCdist(TestCase):
         Y2 = cdist(X1, X2, 'test_sokalsneath')
         _assert_within_tol(Y1, Y2, eps, verbose > 2)
 
+    def test_cdist_custom_notdouble(self):
+        class myclass(object):
+            pass
+
+        def dummy_metric(x, y):
+            if not isinstance(x[0], myclass) or not isinstance(y[0], myclass):
+                raise ValueError("Type has been changed")
+            return 1.123
+        data = np.array([[myclass()]], dtype=object)
+        cdist_y = cdist(data, data, metric=dummy_metric)
+        right_y = 1.123
+        assert_equal(cdist_y, right_y, verbose=verbose > 2)
+
 
 class TestPdist(TestCase):
 
@@ -1136,6 +1149,19 @@ class TestPdist(TestCase):
         pdist_y = pdist(([3.3], [3.4]), "canberra")
         right_y = 0.01492537
         _assert_within_tol(pdist_y, right_y, eps, verbose > 2)
+
+    def test_pdist_custom_notdouble(self):
+        class myclass(object):
+            pass
+
+        def dummy_metric(x, y):
+            if not isinstance(x[0], myclass) or not isinstance(y[0], myclass):
+                raise ValueError("Type has been changed")
+            return 1.123
+        data = np.array([[myclass()], [myclass()]], dtype=object)
+        pdist_y = pdist(data, metric=dummy_metric)
+        right_y = 1.123
+        assert_equal(pdist_y, right_y, verbose=verbose > 2)
 
 
 def within_tol(a, b, tol):


### PR DESCRIPTION
When using pdist with a custom metric there is no need to coerce input to be of type double. this will allow to use for instance an edit distance metric.
